### PR TITLE
🚧 POC: Implemented "incremental build" with Vite

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const { DateTime } = require('luxon');
 const fs = require('fs');
+const { exec } = require('child_process');
 const pluginRss = require('@11ty/eleventy-plugin-rss');
 const pluginSyntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 const pluginNavigation = require('@11ty/eleventy-navigation');
@@ -130,6 +131,21 @@ module.exports = function (eleventyConfig) {
     },
     ui: false,
     ghostMode: false,
+  });
+
+  eleventyConfig.on('afterBuild', async () => {
+    exec(
+      `
+        mkdir -p _root/assets/{images,favicon} &&
+        rsync _site/assets/images/ _root/assets/images &&
+        rsync _site/assets/favicon/ _root/assets/favicon &&
+        diff -ruN _root/ _site/ | sed \'/Binary\ files\ /d\' | patch -d _root -p1
+      `,
+      (err) => {
+        if (err) console.error('Error syncing Vite and 11ty roots:', err);
+        else console.log('Vite and 11ty roots synced');
+      }
+    );
   });
 
   return {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -133,7 +133,7 @@ module.exports = function (eleventyConfig) {
     ghostMode: false,
   });
 
-  eleventyConfig.on('afterBuild', async () => {
+  eleventyConfig.on('afterBuild', () => {
     exec(
       `
         mkdir -p _root/assets/{images,favicon} &&

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 node_modules
 /_site
+/_root
 /src/assets/css
 /src/assets/rev
 /assets.json

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,22 +13,13 @@ for (file of inputFiles) {
 }
  
 module.exports = {
-  root: '_site',
+  root: '_root',
   build: {
     rollupOptions: {
       input,
       output: {
           dir: 'dist/'
       }
-    }
-  },
-  server: {
-    watch: {
-      ignoreInitial: true,
-      waitWriteFinish: {
-        stabilityThreshold: 500,
-        pollInterval: 100
-      },
     }
   }
 };


### PR DESCRIPTION
## Linked Issue

Exploring Virtual-Coffee/virtualcoffee.io#74, builds on #221 🧭

## Description

This change decouples the eleventy and vite builds to reduce thrashing between eleventy (which recreates all files) and vite (which rebuilds all modified files). This was accomplished by separating the eleventy output directory (_site) from the vite input directory (_root), then using rsync to sync binary files, and diff / patch to sync text files between the two directories. This syncing is done after the eleventy build via an eleventy event. Pre-installation of rsync and diff / patch are requirements in this change, but these could be replaced with npm installed dependencies if needed.

## Methodology

The eleventy / vite watch build was a bit slow and had a lot of extra thrashing, and I thought I could make it a bit faster! See the before, and after!

### Before

![Kapture 2021-04-02 at 11 11 34](https://user-images.githubusercontent.com/131928/113483892-9d87ba80-9473-11eb-80ad-2410347e44bf.gif)


### After

![Kapture 2021-04-03 at 11 51 06](https://user-images.githubusercontent.com/131928/113483895-a11b4180-9473-11eb-858b-5f4107de830f.gif)
